### PR TITLE
Fix 8.0b0 deps.

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 4756fc92cca9d8dc520c5e294f55ae42fe411c802212d6d0004f01fdad4fc352
 
 build:
-  number: 0
+  number: 1
   skip: True  # [py<37 or not linux]
   script: {{ PYTHON }} -m pip install . --no-deps --ignore-installed -vv
 
@@ -26,7 +26,7 @@ requirements:
     - cryptography
     - graphene >=2.1,<3
     - jinja2 ==2.11.0,<2.12
-    - metomi-isodatetime ==1!2.0.1
+    - metomi-isodatetime ==1!2.0.2, <1!2.1.0
     - protobuf >=3.15.0,<3.16.0
     - pyasn1
     - python
@@ -40,6 +40,7 @@ requirements:
     - pympler
     - matplotlib-base
     - rx >=1.6,<2 # TODO: https://github.com/conda-forge/cylc-feedstock/pull/3#issuecomment-660716268
+    - packaging
 
 test:
   imports:


### PR DESCRIPTION
Unfortunately I found two problems with the new 8.0b0 release:
- old version of `metomi.isodatetime` package
- no `packaging` package 

These are causing the cylc-uiserver build to fail https://github.com/conda-forge/cylc-uiserver-feedstock/pull/12
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
