### PR TITLE
remove "cylc report-timings" dependencies

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: b50decf1b5af5a062cc280d5ad74b9483902ff32c096a807d1273c1bc02cf9bf
 
 build:
-  number: 0
+  number: 1
   noarch: python
 
 requirements:
@@ -90,9 +90,7 @@ outputs:
         # static graphing
         - graphviz
         - pillow
-        # report-timings
-        - pandas >=1.0,<2
-        - matplotlib-base
+
         # tutorials
         - requests
 
@@ -106,6 +104,16 @@ about:
     Cylc ("silk") is a workflow engine for cycling systems - it orchestrates
     distributed workflows of interdependent cycling tasks that may continue to
     run indefinitely.
+
+    There are two cylc-flow packages:
+    * `cylc-flow`: The full installation, recommended for most uses.
+    * `cylc-flow-base`: A minimal package, recommended for installation on job
+      hosts where the full range of user-facing commands is not required.
+
+    The `cylc report-timings` command requires two additional dependencies
+    which you must specify manually if you want this functionality:
+    * `pandas >=1.0,<2`
+    * `matplotlib-base`
   doc_url: https://cylc.github.io/cylc-doc/
   dev_url: https://github.com/cylc/cylc-flow
 


### PR DESCRIPTION
`cylc report-timings` uses a legacy dependency which pins us to Python 3.10.

Remove legacy dependencies.

Provide instructions for anyone who still wants to use this command.